### PR TITLE
javítások, teszt

### DIFF
--- a/VakVirologusok/src/Program.java
+++ b/VakVirologusok/src/Program.java
@@ -1,15 +1,14 @@
-import agens.Agens;
-import agens.Benito;
-import agens.Kod;
-import agens.Vitustanc;
+import agens.*;
 import util.Anyagok;
+import util.Taska;
 import virologus.Virologus;
 
 public class Program {
 
     public static void main(String[] args) {
-        testAgensEbbol();
-        testKen();
+        //testAgensEbbol();
+        //testKen();
+        testKesztyusKenes();
     }
 
     private static void testAgensEbbol() {
@@ -24,4 +23,43 @@ public class Program {
         Kod k = new Benito(1, new Anyagok(1,1), 1, 1);
         v1.ken(v1, v2, new Agens(k));
     }
+
+    private static void testKesztyusKenes() {
+        Virologus v1 = new Virologus();
+        Virologus v2 = new Virologus();
+        Kod k = new Benito(1, new Anyagok(1,1), 1, 1);
+        v1.setEllenallasErvenyesseg(v1.Visszadob, -1);
+        v2.setEllenallasErvenyesseg(v2.Visszadob, -1);
+        v1.ken(v1, v2, new Agens(k));
+    }
+
+    /*private static void test() {
+
+    }
+
+    private static void test() {
+
+    }
+
+    private static void test() {
+
+    }
+
+    private static void test() {
+
+    }
+
+    private static void test() {
+
+    }
+
+    private static void test() {
+
+    }
+
+    private static void test() {
+
+    }*/
+
+
 }

--- a/VakVirologusok/src/virologus/Virologus.java
+++ b/VakVirologusok/src/virologus/Virologus.java
@@ -114,6 +114,7 @@ public class Virologus {
         boolean siker = true;
         for (Ellenallas ellenallas : ellenallasok) {
             siker = ellenallas.megkent(keno, this, mivel);
+            if (!siker) break;
         }
 
         if (siker) {
@@ -195,7 +196,7 @@ public class Virologus {
     public void setEllenallasErvenyesseg(int id, int szint) {
         Skeleton.metodusEleje(Thread.currentThread().getStackTrace()[1].getMethodName());
 
-        if (id != Visszadob || id != TeljesSzazalekos || id != ReszlegesSzazalekos) throw new IndexOutOfBoundsException("Használd a publikus int-eket az indexelésre!");
+        if (id != Visszadob && id != TeljesSzazalekos && id != ReszlegesSzazalekos) throw new IndexOutOfBoundsException("Használd a publikus int-eket az indexelésre!");
         ellenallasok[id].setErvenyesseg(szint);
 
         Skeleton.metodusVege(Thread.currentThread().getStackTrace()[1].getMethodName());

--- a/VakVirologusok/src/virologus/Viselkedes.java
+++ b/VakVirologusok/src/virologus/Viselkedes.java
@@ -132,7 +132,7 @@ public class Viselkedes {
     public void ken(Virologus ki, Virologus kit, Agens mivel) {
         Skeleton.metodusEleje(Thread.currentThread().getStackTrace()[1].getMethodName());
 
-        mivel.setTtl(2);
+        mivel.setTtl(3);
         kit.megkent(ki, mivel);
 
         Skeleton.metodusVege(Thread.currentThread().getStackTrace()[1].getMethodName());

--- a/VakVirologusok/src/virologus/Visszadob.java
+++ b/VakVirologusok/src/virologus/Visszadob.java
@@ -28,6 +28,10 @@ public class Visszadob extends Ellenallas{
             return true;
         }
 
+        if (!mivel.ttlCsokkent()) { //már nem dobható vissza
+            return true;
+        }
+
         boolean choice = Skeleton.igenNem("Visszadobod?");
         if (choice) {
             ki.megkent(kit, mivel);


### PR DESCRIPTION
Virologusba az ellenallasok vonalának javítása. Virológus setEllenallasErvenyesseg elágazás hiba javítva.

Viselkedésben 3-ra kell állítani a ttl-t amikor megdobunk valakit (1-el csökken az első visszadobnál-2, mégegyel a másiknál-1, a harmadik dobásnál is-0 itt nem lehet már visszadobni).

Visszadob megkent függvénye nézi már a ttl-t is (eddig nem nézte, végtelenszer vissza lehetett dobni).

Uj kesztyus teszt a visszadobásokban (egyben a 0, 1, 2 kesztyűs eset).